### PR TITLE
Remove passenger restart for now

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -32,7 +32,6 @@ the `stages/prod` branch.
 | **Full Deploy** |  The normal deploy, releases all changes on the `main`  branch to production. | Twice a week | [@login-deployer][deployer-rotation] |
 | **Patch Deploy** | A deploy that cherry-picks particular changes to be deployed | For urgent bug fixes | The engineer handling the urgent issue |
 | **Off-Cycle/Mid-Cycle Deploy** | Releases all changes on the `main` branch, sometime during the middle of a sprint | As needed, or if there are too many changes needed to cleanly cherry-pick as a patch | The engineer that needs the changes deployed |
-| **Passenger Restart** | A "deploy" that just updates configurations without the need to scale up/down instances like the config recycle below, does not deploy any new code, see [passenger restart](#passenger-restart) | As needed | The engineer that needs the changes deployed |
 | **Config Recycle** | A deploy that just updates configurations, and does not deploy any new code, see [config recycle](#config-recycle) | As needed | The engineer that needs the changes deployed |
 | **No-Migration Recycle** | A deploy that skips migrations, see [no-migration recycle](#no-migration-recycle) | As needed | The engineer that needs the changes deployed |
 
@@ -301,26 +300,6 @@ As soon as possible, ensure that the deploy is rolled back by reverting the `sta
 
 If you do end up rolling back a deploy, schedule a blameless retrospective afterwards. These help
 us think about new checks, guardrails, or monitoring to help ensure smoother deploys in the future.
-
-### Passenger restart
-
-{%- capture alert_content -%}
-**2022-03-15**: This script is **not safe for prod use** at this time, it drops live requests instead of rotating smoothly. See [identity-devops#5651](https://github.com/18F/identity-devops/issues/5651) for more information. Only use it in emergency cases, or in a lower environment where live traffic does not matter.
-{%- endcapture -%}
-
-{% include alert.html content=alert_content alert_class="usa-alert--error" %}
-
-A passenger restart is a quicker way to pick up changes to configuration in S3 without the need
-to scale up new instances. See [`passenger-restart` docs]({% link _articles/devops-scripts.md %}#passenger-restart).
-
-1. Make the config changes
-
-1. Run the passenger restart command for the environment from the identity-devops repository
-   ```bash
-   # Restart passenger on the IDP instances
-   aws-vault exec prod-power -- bin/ssm-command -d passenger-restart -o -r idp -e prod
-   ```
-
 
 ### Config Recycle
 

--- a/_articles/appdev-secrets-configuration.md
+++ b/_articles/appdev-secrets-configuration.md
@@ -18,9 +18,6 @@ environment by merging default values with an environment-specific YAML file.
 * In deployed environments, this file is downloaded from S3 when activating or deploying an instance
   (see [`deploy/activate`][deploy-activate] and the [`activate.rb`][download-from-s3]).
 
-**Changing configuration for a deployed application [requires a passenger restart][passenger-restart]**, since
-this merge step only happens at activation.
-
 The S3 buckets that contain secrets are versioned, so we can recover old versions
 if needed.
 
@@ -30,7 +27,6 @@ machine when done.
 
 [deploy-activate]: https://github.com/18F/identity-idp/blob/main/deploy/activate
 [download-from-s3]: https://github.com/18F/identity-idp/blob/a95fd33d24c6761818993cfbc334a28986783034/lib/deploy/activate.rb#L93-L97
-[passenger-restart]: {% link _articles/appdev-deploy.md %}#passenger-restart
 
 ## Using `app-s3-secret`
 

--- a/_articles/devops-scripts.md
+++ b/_articles/devops-scripts.md
@@ -536,29 +536,6 @@ aws-vault exec sandbox-power --
     ./bin/ssm-command -h
 ```
 
-### `passenger-restart`
-
-{%- capture alert_content -%}
-**2022-03-15**: This script is **not safe for prod use** at this time, it drops live requests instead of rotating smoothly. See [identity-devops#5651](https://github.com/18F/identity-devops/issues/5651) for more information. Only use it in emergency cases, or in a lower environment where live traffic does not matter.
-{%- endcapture -%}
-
-{% include alert.html content=alert_content alert_class="usa-alert--error" %}
-
-"Safely" restart the NGINX/Passenger service which reloads `application.yml` from
-S3.
-
-```bash
-aws-vault exec sandbox-power --
-    ./bin/ssm-command -d passenger-restart -r idp -e dev
-```
-
-If this fails it is recommended that you perform a recycle to ensure
-all instances are running from the same configuration.
-
-Check out [passenger-restart](https://github.com/18F/identity-devops/wiki/Troubleshooting-Quick-Reference#passenger-restart) for more information on what the command can do
-
-### `worker-restart`
-
 Safely restart GoodJob (idp-workers) service.
 
 ```bash


### PR DESCRIPTION
It was used [here](https://gsa-tts.slack.com/archives/C0NGESUN5/p1710513106909849?thread_ts=1710512103.049979&cid=C0NGESUN5) when we should have avoided it. A similar command may be coming to replace passenger-restart, and we can undo these changes then.