### PR TITLE
Document announcing in Slack for config recycle

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -308,6 +308,9 @@ new configurations (config from S3).
 
 1. Make the config changes
 
+1. Announce the configuration change in `#login-appdev`
+    - Share the diff as a thread comment, omitting any sensitive information
+
 1. Recycle the boxes
 
    ```bash


### PR DESCRIPTION
Conventionally, we expect that any recycles to production should be shared in Slack. This is mentioned as part of the regular deployment process, but was not clear as part of a configuration recycle.