### PR TITLE
Improve documentation for handling expiring PIV/CAC certificates

### DIFF
--- a/_articles/appdev-oncall-guide.md
+++ b/_articles/appdev-oncall-guide.md
@@ -94,7 +94,7 @@ end
 
 If you see a Slack alert like this, it means that a certificate used to verify PIV/CAC cards will expire within 30 days.
 
-Refer to [Troubleshooting expiring PIV/CAC certs]({% link _articles/toubleshooting-expiring-pivcac.md %}) for guidance on replacing an expiring certificate.
+Refer to [Troubleshooting expiring PIV/CAC certs]({% link _articles/troubleshooting-expiring-pivcac.md %}) for guidance on replacing an expiring certificate.
 
 ## Response Times
 

--- a/_articles/appdev-oncall-guide.md
+++ b/_articles/appdev-oncall-guide.md
@@ -92,14 +92,9 @@ end
 
 ![Screenshot of expiring PKI Slack alert]({{ site.baseurl }}/images/slack-pki-cert-alert.jpg)
 
-If you see a Slack alert like this, it means that a cert used to verify PIV/CAC cards will expire in 30 days. Check the
-[Federal Public Key Infrastructure Guides Certificate Authorities](https://fpki.idmanagement.gov/ca/) list for info
-on the the most up to date certs.
+If you see a Slack alert like this, it means that a certificate used to verify PIV/CAC cards will expire within 30 days.
 
-Related articles:
-  - [Common OpenSSL command line recipes]({% link _articles/openssl-recipes.md %})
-  - [PIV/CAC Debugging guide]({% link _articles/troubleshooting-pivcacs.md %})
-
+Refer to [Troubleshooting expiring PIV/CAC certs]({% link _articles/toubleshooting-expiring-pivcac.md %}) for guidance on replacing an expiring certificate.
 
 ## Response Times
 

--- a/_articles/troubleshooting-expiring-pivcac.md
+++ b/_articles/troubleshooting-expiring-pivcac.md
@@ -109,6 +109,13 @@ Finally, read in the certificates from the bundle and look for a replacement:
 openssl pkcs7 -inform DER -in tmp/bundle.p7c -print_certs -text
 ```
 
+## Using FPKI Notifications to prepare for a scheduled replacement
+
+If you aren't able to find a replacement certificate using the options described above, it may not
+be issued yet. GSA's FICAM program publishes [notifications for Federal PKI ecosystem changes](https://www.idmanagement.gov/fpki/notifications/#notifications),
+where you may find a notice describing whether to expect a replacement certificate to be issued
+before the scheduled expiration of the certificate.
+
 ## Using CloudWatch to find issuers and service providers
 
 CloudWatch may be used to find certificate-related errors by issuer and service provider.

--- a/_articles/troubleshooting-expiring-pivcac.md
+++ b/_articles/troubleshooting-expiring-pivcac.md
@@ -116,6 +116,25 @@ be issued yet. GSA's FICAM program publishes [notifications for Federal PKI ecos
 where you may find a notice describing whether to expect a replacement certificate to be issued
 before the scheduled expiration of the certificate.
 
+## Handling expiring certificates when no replacements exist
+
+If you've exhausted all of the options described above and there are no replacement certificates
+available up to and beyond the expiration of certificate, then it's quite possible that the
+certificate is expected to expire and not be replaced.
+
+In these scenarios, you should:
+
+1. Check logs for PKI activity issued by this certificate, to understand expected impact over the
+   course of a few weeks leading up to the expiration of the certificate.
+    ```
+    # Log group: prod_/srv/pki-rails/shared/log/production.log
+    filter issuer like /CN=[CN of expiring certificate]/
+    ```
+2. Remove the certificate from [`identity-pki`](https://github.com/18f/identity-pki) if there is
+   no replacement, the certificate has expired, and there is no activity reported in the logs above
+   which would indicate that end-users would be impacted by the expiration and removal of the
+   certificate.
+
 ## Using CloudWatch to find issuers and service providers
 
 CloudWatch may be used to find certificate-related errors by issuer and service provider.

--- a/cspell.json
+++ b/cspell.json
@@ -50,7 +50,9 @@
     "wargames",
     "wireframe",
     "wireframes",
-    "yubikey"
+    "yubikey",
+    "FICAM",
+    "FPKI"
   ],
   "patterns": [
     {


### PR DESCRIPTION
## 🛠 Summary of changes

Updates documentation for handling expiring PIV/CAC certificates.

Notably:

- Updates the appdev on-call guide to reference the detailed article for troubleshooting expiring certificates
- Adds a reference to [notifications for Federal PKI ecosystem changes](https://www.idmanagement.gov/fpki/notifications/#notifications), which often include postings informing about an upcoming replacement certificate
   - For example, a certificate expiring at the time of writing ["Lockheed Martin Root Certification Authority 6"](https://github.com/18F/identity-pki/blob/main/config/certs/C%3DUS%2C%20ST%3DColorado%2C%20L%3DDenver%2C%20O%3DLockheed%20Martin%20Corporation%2C%20OU%3DCertification%20Authority%2C%20CN%3DLockheed%20Martin%20Root%20Certification%20Authority%206.pem) has a related posting advising "CertiPath intends to issue a new cross certificate to Lockheed Martin Root CA 6 on or about April 16, 2024" ([LG-12998](https://cm-jira.usa.gov/browse/LG-12998))
- Adds a reference to removing expired certificates when no replacements exist
   - For example, a certificate expiring at the time of writing ["Exostar Federated Identity Service Root CA 2"](https://github.com/18F/identity-pki/blob/main/config/certs/DC%3Dcom%2C%20DC%3Devincible%2C%20CN%3DExostar%20Federated%20Identity%20Service%20Signing%20CA%203.pem) has no replacements as is slated for removal ([LG-12997](https://cm-jira.usa.gov/browse/LG-12997))