### PR TITLE
Remove text stating updates can be made by whatever means necessary

### DIFF
--- a/_articles/appdev-secrets-configuration.md
+++ b/_articles/appdev-secrets-configuration.md
@@ -21,10 +21,6 @@ environment by merging default values with an environment-specific YAML file.
 The S3 buckets that contain secrets are versioned, so we can recover old versions
 if needed.
 
-At the end of the day, since these are just files in S3, you can use whatever workflow
-you want to download, edit, and write them. Make sure you clean up files on your local
-machine when done.
-
 [deploy-activate]: https://github.com/18F/identity-idp/blob/main/deploy/activate
 [download-from-s3]: https://github.com/18F/identity-idp/blob/a95fd33d24c6761818993cfbc334a28986783034/lib/deploy/activate.rb#L93-L97
 


### PR DESCRIPTION
Currently the page regarding [Secrets and Configuration](https://handbook.login.gov/articles/appdev-secrets-configuration.html) includes language implying that updates can be made by editing the secrets file in s3 by downloading, editing, and uploading. This is not recommended, users should use the `app-s3-secret` script to make edits. So this PR removes that language.

[Conversation in Slack regarding this change](https://gsa.enterprise.slack.com/archives/C16RSBG49/p1715694023104519)