### PR TITLE
Add a SQL style guide

### DIFF
--- a/_articles/queries.md
+++ b/_articles/queries.md
@@ -3,6 +3,7 @@ title: "Reporting Queries"
 description: "Queries to run in the Rails console for common reporting questions"
 layout: article
 category: "Reporting"
+subcategory: "Queries"
 ---
 
 ## Query timeout

--- a/_articles/sql-style-guide.md
+++ b/_articles/sql-style-guide.md
@@ -1,0 +1,67 @@
+---
+title: "SQL Style Guide"
+description: "Conventions for formatting SQL queries"
+layout: article
+category: "Reporting"
+subcategory: "Queries"
+---
+
+This is a guide for writing "raw" SQL queries, used in ETLs and reports. It does
+not apply to queries that are auto-generated via ORMs like ActiveRecord.
+
+Currently we do not have any automated linting/enforcement of this guide.
+
+## Keywords
+
+Capitalize keywords
+
+```sql
+-- DO
+SELECT 1
+FROM mytable;
+
+-- DO NOT
+select 1
+from mytable;
+```
+
+## Commas
+
+Prefer leading commas (they usually make for less diff noise when adding or removing items in a list)
+
+```sql
+-- DO
+SELECT
+  col1
+, col2
+, col3
+FROM mytable;
+
+-- DO NOT
+SELECT
+  col1,
+  col2,
+  col3
+FROM mytablel
+```
+
+## `SELECT *`
+
+Avoid `SELECT *` and select specific fields when possible. Using explicit columns
+makes analysis of queries easier.
+
+(This rule applies most to checked-in code. For running test queries interactively,
+`SELECT *` is totally fine).
+
+```sql
+-- DO
+SELECT
+  col1
+, col2
+, col3
+FROM mytable;
+
+-- DO NOT
+SELECT *
+FROM mytable;
+```


### PR DESCRIPTION
Starts a small SQL style guide! Like it says inside, it's not enforced, but I would like to start norming as a team on these!

I found that [Gitlab has a style guide](https://handbook.gitlab.com/handbook/business-technology/data-team/platform/sql-style-guide/) which I skimmed for reference.

I would like to find a way to use an automated tool like [sqlfluff](https://github.com/sqlfluff/sqlfluff) that they mention, but currently, it would not work for our codebases that have SQL embedded inside ruby files. I've got some ideas for how we can cobble something togethe.