### PR TITLE
Override GSA-TTS .allstar config for "dismiss stale reviews"

### DIFF
--- a/.allstar/branch_protection.yaml
+++ b/.allstar/branch_protection.yaml
@@ -1,0 +1,1 @@
+dismissStale: false


### PR DESCRIPTION
**Why**: We believe this still meets the AC-2 control, while also allowing for a more flexible workflow for Login.gov contributors

Based on a [Slack conversation in #tts-devtools](https://gsa-tts.slack.com/archives/C02U4Q9M5UH/p1717091155987799), it sounds like we might be able to override this