### PR TITLE
Add \ to escape newlines for multi-line bash commands

### DIFF
--- a/_articles/devops-scripts.md
+++ b/_articles/devops-scripts.md
@@ -315,7 +315,7 @@ aws-vault exec prod-power -- \
 Lists servers in an environment as a table
 
 ```bash
-aws-vault exec sandbox-power --
+aws-vault exec sandbox-power -- \
     ./bin/ls-servers -e dev
 ```
 
@@ -398,7 +398,7 @@ split up slices that have 10k responses (the limit) to ensure a complete
 listing of results.
 
 ```bash
-aws-vault exec sandbox-power --
+aws-vault exec sandbox-power -- \
     ./bin/query-cloudwatch \
   --app idp --env dev --log events.log \
   --from 10d --slice 1d --query "$QUERY"
@@ -450,7 +450,7 @@ Imitates `scp` by copying a file in and out of S3. Use the instance ID to refer 
 (see [`ls-servers`](#ls-servers) to find them).
 
 ```bash
-aws-vault exec sandbox-power --
+aws-vault exec sandbox-power -- \
     ./bin/scp-s3 i-abcdef1234:/tmp/file.txt ./file.txt
 ```
 
@@ -481,7 +481,7 @@ Shows usage plus a list of the available SSM session documents for the
 application environment.
 
 ```bash
-aws-vault exec sandbox-power --
+aws-vault exec sandbox-power -- \
     ./bin/ssm-instance -h
 ```
 
@@ -490,7 +490,7 @@ aws-vault exec sandbox-power --
 Opens a Rails console (in read-only mode)
 
 ```bash
-aws-vault exec sandbox-power --
+aws-vault exec sandbox-power -- \
     ./bin/ssm-instance --document rails-c --any asg-dev-idp
 ```
 
@@ -499,7 +499,7 @@ aws-vault exec sandbox-power --
 Opens a Rails console (in read-write mode). **Be careful please**.
 
 ```bash
-aws-vault exec sandbox-power --
+aws-vault exec sandbox-power -- \
     ./bin/ssm-instance --document rails-w --any asg-dev-idp
 ```
 
@@ -508,7 +508,7 @@ aws-vault exec sandbox-power --
 Tails and streams cloudwatch logs, specifically `/var/log/cloud-init-output.log`. Useful for checking that a box spins up correctly, such as [during a deploy]({% link _articles/appdev-deploy.md %}#follow-the-process).
 
 ```bash
-aws-vault exec sandbox-power --
+aws-vault exec sandbox-power -- \
     ./bin/ssm-instance --document tail-cw --any asg-dev-idp
 ```
 
@@ -532,14 +532,14 @@ Shows usage plus a list of the available SSM command documents for the
 application environment.
 
 ```bash
-aws-vault exec sandbox-power --
+aws-vault exec sandbox-power -- \
     ./bin/ssm-command -h
 ```
 
 Safely restart GoodJob (idp-workers) service.
 
 ```bash
-aws-vault exec sandbox-power --
+aws-vault exec sandbox-power -- \
     ./bin/ssm-command -d worker-restart -r worker -e dev
 ```
 

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'HTML' do
         aggregate_failures do
           expect(doc).to have_unique_ids
           expect(doc).to link_internally_for_handbook_articles
+          expect(doc).to escape_newlines_in_bash_code_snippets
         end
       end
     end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -44,3 +44,17 @@ RSpec::Matchers.define :link_internally_for_handbook_articles do
     "expected that #{actual.url} would not link to external version of articles in this handbook, but found:\n#{articles.to_a.join("\n")}"
   end
 end
+
+RSpec::Matchers.define :escape_newlines_in_bash_code_snippets do
+  match do |actual|
+    doc = actual
+
+    doc.css('.language-bash code').each do |code_elem|
+      expect(code_elem.inner_text).to_not match(/ --\s*$/)
+    end
+  end
+
+  failure_message do |actual|
+    "expected that #{actual.url} would escape newlines with \\ in bash scripts"
+  end
+end


### PR DESCRIPTION
## Before

If copy-pasted some of these commands would error because the missing `\` means that it was two separate commands

## After

Copy-pasting these commands works! Requires less thingking

## Alternative

Another option would be to one-line all of these (but that means more horizontal scrolling)