### PR TITLE
Remove instruction to set risc_notifications_active_job_enabled

### DIFF
--- a/_articles/appdev-risc-ruby-worker-jobs.md
+++ b/_articles/appdev-risc-ruby-worker-jobs.md
@@ -50,4 +50,3 @@ instances.
 2. Additionally update the environment's [`application.yml`]({% link _articles/appdev-secrets-configuration.md %})
 
     - set **push_notifications_enabled**: `'true'` (this enables sending SET tokens)
-    - Set **risc_notifications_active_job_enabled** `'true'` (this enables sending SET token via Ruby workers)


### PR DESCRIPTION
The feature flag is obsolete.