### PR TITLE
Rename postmortem template to incident review template

### DIFF
--- a/_articles/incident-review-template.md
+++ b/_articles/incident-review-template.md
@@ -1,12 +1,13 @@
 ---
-title: "Postmortem Template"
+title: "Incident Review Template"
 description:
 layout: article
 category: "Development"
 subcategory: Documentation
+redirect_from: /articles/postmortem-template.html
 ---
 
-After incidents, we hold postmortems or retrospectives. Our postmortem template is:
+After incidents, we hold incident reviews (previously called postmortems). Our postmortem template is:
 
 <https://docs.google.com/document/d/1A9y94VgHPOcaCCTdGRh0aWINOrBjUwo2ZepzBlTM--8/edit>
 

--- a/_articles/product-artifacts.md
+++ b/_articles/product-artifacts.md
@@ -84,3 +84,4 @@ Brief explanatory documents. Not actually restricted to one page.
 
 - [Rollplans]({% link _articles/rollplans.md %}), for live changes to production
 - [Engineering Design Docs]({% link _articles/eng-design-doc.md %}){: #eng-design-doc .deprecated-link} (deprecated), superceded by [RFCs](#rfcs)
+- [Incident Review]({% link _articles/incident-review-template.md %}), for a retrospective on incidents


### PR DESCRIPTION
**Why**: We have moved away from the term postmortem