### PR TITLE
Add cloudwatch query instructions to log in via the UX

### DIFF
--- a/_articles/cloudwatch-101.md
+++ b/_articles/cloudwatch-101.md
@@ -25,14 +25,14 @@ You will need an AWS account and access. See [setting up aws-vault][aws-vault] f
     ```
     - Via AWS GUI:
     The console login method does not allow a user to switch roles or environments (ie, `sandbox-power`). If you know you will need to switch back and forth, it may be easier to log in via the AWS GUI.
-    https://us-east-2.signin.aws.amazon.com
-    Click the `Sign In to the Console` button on the top right
-    Input Account ID as `login-master`, your IAM username and password
-    Click `Sign In`
-    Generate an MFA Code [with your Yubikey](https://gitlab.login.gov/lg/identity-devops/-/wikis/Setting-Up-your-Login.gov-Infrastructure-Configuration#configuring-a-mfa-authenticator)
-    Enter MFA code
-    Click `Submit`
-    Click on the top right user dropdown and click on `Switch role` to log into the appropriate role.
+        - [Navigate to AWS](https://us-east-2.signin.aws.amazon.com)
+        - Click the `Sign In to the Console` button on the top right
+        - Input Account ID as `login-master`, and your IAM username and password
+        - Click `Sign In`
+        - Generate an MFA Code [with your Yubikey](https://gitlab.login.gov/lg/identity-devops/-/wikis/Setting-Up-your-Login.gov-Infrastructure-Configuration#configuring-a-mfa-authenticator)
+        - Enter MFA code
+        - Click `Submit`
+        - Click on the top right user dropdown and click on `Switch role` to log into the appropriate role.
 
 1. Search for "CloudWatch"
 

--- a/_articles/cloudwatch-101.md
+++ b/_articles/cloudwatch-101.md
@@ -16,13 +16,23 @@ You will need an AWS account and access. See [setting up aws-vault][aws-vault] f
 ### Getting to CloudWatch Insights
 
 1. Log in to AWS
-
+    - Via terminal:
     ```bash
     # depending on the roles you have pick between
     aws-vault login prod-analytics
     # or
     aws-vault login prod-power
     ```
+    - Via AWS GUI:
+    The console login method does not allow a user to switch roles or environments (ie, `sandbox-power`). If you know you will need to switch back and forth, it may be easier to log in via the AWS GUI.
+    https://us-east-2.signin.aws.amazon.com
+    Click the `Sign In to the Console` button on the top right
+    Input Account ID as `login-master`, your IAM username and password
+    Click `Sign In`
+    Generate an MFA Code [with your Yubikey](https://gitlab.login.gov/lg/identity-devops/-/wikis/Setting-Up-your-Login.gov-Infrastructure-Configuration#configuring-a-mfa-authenticator)
+    Enter MFA code
+    Click `Submit`
+    Click on the top right user dropdown and click on `Switch role` to log into the appropriate role.
 
 1. Search for "CloudWatch"
 

--- a/_articles/cloudwatch-101.md
+++ b/_articles/cloudwatch-101.md
@@ -103,7 +103,7 @@ fields @timestamp, name, properties.event_properties.success, @message
 
 ## Writing Queries
 
-The [AWS documentation for CloudWatch Insights][aws-docs] is fairly thorough. If anything is left unaswered after reading this guide, that documentation is likely to contain the answer.
+The [AWS documentation for CloudWatch Insights][aws-docs] is fairly thorough. If anything is left unanswered after reading this guide, that documentation is likely to contain the answer.
 
 ### Similarity to SQL
 


### PR DESCRIPTION
Added instructions for logging in via AWS directly, since that's easier if you know you need to switch roles. 