### PR TITLE
Add GSA-TTS prerequisite to Cloud.gov Pages access

### DIFF
--- a/_articles/cloud-gov-pages.md
+++ b/_articles/cloud-gov-pages.md
@@ -15,6 +15,8 @@ Login.gov uses [Cloud.gov Pages][cloud-gov-pages] as its hosting provider for ou
 
 ## Requesting Access to Cloud.gov Pages
 
+To be able to manage Login.gov's static sites in Cloud.gov Pages or edit content on those sites using Netlify CMS, you will need to be a part of the `identity-core` team within the [GSA-TTS GitHub organization](https://github.com/gsa-tts). If you are not already part of this team, you must first [request access to be added](https://handbook.login.gov/articles/github-gitlab.html#requesting-access).
+
 **For those requesting access:** Reach out to any of the organization managers listed in the [Handbook Appendix][handbook-appendix-cloud-gov]. After you have been added to the organization, you will need to [sign in to the Cloud.gov Pages dashboard with GSA.gov][cloud-gov-pages-login] _before_ authenticating with Netlify CMS.
 
 **For managers granting access:** [Sign in to the Cloud.gov Pages dashboard with GSA.gov][cloud-gov-pages-login], then add a new member under the "Add user" option of the [Login.gov Organization][cloud-gov-login-gov-org]


### PR DESCRIPTION
Being able to manage static sites either via Cloud.gov Pages or Netlify CMS requires additional permissions to the GSA-TTS GitHub organization. This is a common source of confusion.

The goal of this pull request is to add additional text to the Cloud..gov Pages handbook article to explain this prerequisite, and link to existing guidance on requesting access to be added to the relevant GitHub teams.