### PR TITLE
Use link helper to generate GitHub article URL

### DIFF
--- a/_articles/cloud-gov-pages.md
+++ b/_articles/cloud-gov-pages.md
@@ -15,7 +15,7 @@ Login.gov uses [Cloud.gov Pages][cloud-gov-pages] as its hosting provider for ou
 
 ## Requesting Access to Cloud.gov Pages
 
-To be able to manage Login.gov's static sites in Cloud.gov Pages or edit content on those sites using Netlify CMS, you will need to be a part of the `identity-core` team within the [GSA-TTS GitHub organization](https://github.com/gsa-tts). If you are not already part of this team, you must first [request access to be added](https://handbook.login.gov/articles/github-gitlab.html#requesting-access).
+To be able to manage Login.gov's static sites in Cloud.gov Pages or edit content on those sites using Netlify CMS, you will need to be a part of the `identity-core` team within the [GSA-TTS GitHub organization](https://github.com/gsa-tts). If you are not already part of this team, you must first [request access to be added]({% link _articles/github-gitlab.md %}#requesting-access).
 
 **For those requesting access:** Reach out to any of the organization managers listed in the [Handbook Appendix][handbook-appendix-cloud-gov]. After you have been added to the organization, you will need to [sign in to the Cloud.gov Pages dashboard with GSA.gov][cloud-gov-pages-login] _before_ authenticating with Netlify CMS.
 


### PR DESCRIPTION
Updates Cloud.gov Pages article to use the `{% link %}` helper to generate a URL to the GitHub article, so that it works correctly in local and preview environments.

Addresses https://github.com/GSA-TTS/identity-handbook/pull/613#discussion_r1811092839

**Testing Instructions:**

1. Go to https://federalist-7d0b2b76-42fc-4df1-9825-8c3cd77e0a15.sites.pages.cloud.gov/preview/gsa-tts/identity-handbook/aduth-cloud-gov-link-helper/articles/cloud-gov-pages.html
2. Take note of the URL hostname in your address bar
3. Click "request access to be added"
4. Observe that you're still on the same URL hostname from Step 2