### PR TITLE
Change language around deploy cadence

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -13,14 +13,11 @@ A few notes on our deploy process.
 
 ### Cadence
 
-**When to deploy:** ✅
-- Typically we do a full deploy twice weekly, on Tuesdays and Thursdays.
-
-**When _not_ to deploy:** ❌
-- We try to avoid deploying on Fridays, to minimize the chances of introducing a
-  bug and having to scramble to fix it before the weekend
-- When the deploy falls on a holiday, or any other time when many team members are on vacation, such
-  as New Years / end of year.
+- Most weeks, we plan to do a full deploy on Tuesday and Thursday.
+- We are able to deploy at any time, but off-cycle deploys should be communicated with on-callers if possible
+- However, we do try to avoid deploying on days when more people will be out. This includes:
+   - Fridays to minimize scrambling to fix before the weekend.
+   - Before holidays, or any other time when many team members are on vacation, such as New Years / end of year.
 
 ### Types of Deploys
 

--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -15,9 +15,10 @@ A few notes on our deploy process.
 
 - Most weeks, we plan to do a full deploy on Tuesday and Thursday.
 - We are able to deploy at any time, but off-cycle deploys should be communicated with on-callers if possible
-- However, we do try to avoid deploying on days when more people will be out. This includes:
-   - Fridays to minimize scrambling to fix before the weekend.
-   - Before holidays, or any other time when many team members are on vacation, such as New Years / end of year.
+- We default to not deploying if we expect most of the team will be out on the following day. Some examples are:
+   - Fridays
+   - The day before a Federal holiday
+   - The day before a large swath of the team is expected to be on vacation
 
 ### Types of Deploys
 

--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -15,10 +15,10 @@ A few notes on our deploy process.
 
 - Most weeks, we plan to do a full deploy on Tuesday and Thursday.
 - We are able to deploy at any time, but off-cycle deploys should be communicated with on-callers if possible
-- We default to not deploying if we expect most of the team will be out on the following day. Some examples are:
+- We default to not deploying if we expect most of the team will be out on the day(s) following. Some examples are:
    - Fridays
-   - The day before a Federal holiday
-   - The day before a large swath of the team is expected to be on vacation
+   - Before a holiday
+   - Before a large part of the team is expected to be on leave
 
 ### Types of Deploys
 


### PR DESCRIPTION
Following a discussion on the potential understanding of "When to deploy" / "When to not deploy" as more binding than originally intended. I added a few changes and restructured this part to hopefully make it clearer that we have a regular schedule for deployments, that we can deploy at other times, and there are times we may consider not deploying due to less time and people being available if something goes wrong.