### PR TITLE
Remove GPG_TTY system variable from tag-release documentation

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -252,7 +252,6 @@ Where `<PR_NUMBER>` is the number of the _merged_ PR.
 1. In the application repository, use your GPG key to tag the release.
    ```bash
    git checkout stages/prod && git pull
-   export GPG_TTY=$(tty)
    bin/tag-release
    ```
 2. Add release notes in GitHub:


### PR DESCRIPTION
The [bin/tag-release](https://gitlab.login.gov/lg/identity-pki/-/blob/fb7b99db26a5c518709123e76c056bdfe610226d/bin/tag-release#L7) script includes setting this environment variable, so we can remove it here

```
#!/bin/sh

set -e
set -x
TAG=$(date -u +"%Y-%m-%dT%H%M%S")

GPG_TTY=$(tty) git tag -s $TAG -m "$TAG release"
git push origin $TAG
```