### PR TITLE
Rename handbook title "Login.gov Handbook"

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-title: Login Handbook
+title: Login.gov Handbook
 permalink: /
 layout: article
 ---


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the handbook's homepage title from "Login Handbook" to "Login.gov Handbook".

Our organization is not called "Login", so our handbook should reflect who we are.

## 📜 Testing Plan

Verify title (both `<h1>` and `<title>`) show "Login.gov Handbook", not "Login Handbook".

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/ee19ea73-eeff-4a76-926e-4ca99c1b2480)|![image](https://github.com/user-attachments/assets/5e66b9a2-23f1-4c55-b6fa-a07c1738b832)
