### PR TITLE
Fix logo homepage link in Cloud.gov Pages preview

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,7 @@
     <header class="usa-header usa-header--extended">
       <div class="usa-navbar">
         <div class="usa-logo">
-          <a href="/" title="Home" aria-label="Home">
+          <a href="{{ site.baseurl }}/" title="Home" aria-label="Home">
             <img src="{{ site.baseurl }}/assets/img/login-gov-logo.svg" class="usa-logo__img" alt="Login.gov" />
             <em class="usa-logo__text">Handbook</em>
           </a>


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where clicking the logo in a Cloud.gov Pages preview environment results in a 404.

Cloud.gov Pages are served from subdirectories, so hard-coding `"/"` will always result in a 404 in these environments, and should be prepended with `{{ site.baseurl }}`.

Related resource: https://mademistakes.com/mastering-jekyll/site-url-baseurl/

## 📜 Testing Plan

1. Go to preview site for this branch
2. Click logo
3. Observe that you're directed to the homepage of the handbook