### PR TITLE
Add link to internal handbook in homepage intro

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 ruby '~> 3.2.2'
 
+gem "activemodel", "~> 8.0.0"
 gem "actionpack", "~> 8.0.0"
 gem "activesupport", "~> 8.0.0"
 gem "actionview", "~> 8.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,8 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    activemodel (8.0.0.1)
+      activesupport (= 8.0.0.1)
     activesupport (8.0.0.1)
       base64
       benchmark (>= 0.3)
@@ -176,6 +178,7 @@ PLATFORMS
 DEPENDENCIES
   actionpack (~> 8.0.0)
   actionview (~> 8.0.0)
+  activemodel (~> 8.0.0)
   activesupport (~> 8.0.0)
   html-proofer (~> 4.4.3)
   jekyll (~> 4)

--- a/_components/alert_component.html.erb
+++ b/_components/alert_component.html.erb
@@ -1,0 +1,5 @@
+<%= tag.div(**tag_options, class: css_class, role:) do %>
+  <div class="usa-alert__body">
+    <%= content_tag(text_tag, content, class: 'usa-alert__text') %>
+  </div>
+<% end %>

--- a/_components/alert_component.rb
+++ b/_components/alert_component.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class AlertComponent < BaseComponent
+  attr_reader :type, :message, :tag_options, :text_tag
+
+  validates_inclusion_of :type, in: [nil, :info, :success, :warning, :error, :emergency]
+
+  def initialize(type: nil, text_tag: 'p', message: nil, **tag_options)
+    @type = type
+    @message = message
+    @tag_options = tag_options
+    @text_tag = text_tag
+  end
+
+  def role
+    if type == :error
+      'alert'
+    else
+      'status'
+    end
+  end
+
+  def css_class
+    ['usa-alert', modifier_css_class, *tag_options[:class]]
+  end
+
+  def modifier_css_class
+    case type
+    when :info
+      'usa-alert--info'
+    when :success
+      'usa-alert--success'
+    when :error
+      'usa-alert--error'
+    when :warning
+      'usa-alert--warning'
+    when :emergency
+      'usa-alert--emergency'
+    end
+  end
+
+  def content
+    @message || super
+  end
+end

--- a/_components/base_component.rb
+++ b/_components/base_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'active_model'
+
+class BaseComponent < ViewComponent::Base
+  include ActiveModel::Model
+
+  def before_render
+    validate!
+  end
+end

--- a/_components/breadcrumb_component.rb
+++ b/_components/breadcrumb_component.rb
@@ -1,1 +1,1 @@
-class BreadcrumbComponent < ViewComponent::Base; end
+class BreadcrumbComponent < BaseComponent; end

--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ to [avoid contributing sensitive information][sensitive-information].
 [sensitive-information]: {{ site.baseurl }}/articles/contributing.html#sensitive-information
 
 {% component alert type=:info %}
-Internal documentation can be found in our [🔒 Internal Login.gov Handbook](https://lg-public.pages.production.gitlab.login.gov/identity-internal-handbook/).
+Internal documentation can be found in our [Internal Login.gov Handbook](https://lg-public.pages.production.gitlab.login.gov/identity-internal-handbook/).
 {% endcomponent %}
 
 ## Categories

--- a/index.md
+++ b/index.md
@@ -12,6 +12,10 @@ to [avoid contributing sensitive information][sensitive-information].
 
 [sensitive-information]: {{ site.baseurl }}/articles/contributing.html#sensitive-information
 
+{% component alert type=:info %}
+Internal documentation can be found in our [🔒 Internal Login.gov Handbook](https://lg-public.pages.production.gitlab.login.gov/identity-internal-handbook/).
+{% endcomponent %}
+
 ## Categories
 
 <div class="margin-bottom-4"></div>


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the homepage to include a visually-distinct link to the internal handbook.

Currently, it's hard to know that an internal handbook even exists with additional handbook material. The intent here is to improve awareness of its existence, without being too overly distracting.

Related Slack discussion: https://gsa-tts.slack.com/archives/CEUQ9FXNJ/p1733941222366069

## 📜 Testing Plan

1. Go to preview URL
2. See alert with link to internal handbook
3. Verify that the link is functional

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/39eb6e6f-3b02-47ed-93a3-a2b1f6402ff1)|![image](https://github.com/user-attachments/assets/33de3946-7b01-455e-a82e-f287a479a9c5)
