### PR TITLE
Remove inherent padding from breadcrumb

### DIFF
--- a/_components/breadcrumb_component.html.erb
+++ b/_components/breadcrumb_component.html.erb
@@ -1,5 +1,5 @@
-<nav class="<%= css_class %>" aria-label="Breadcrumbs,,">
+<%= tag.nav(**tag_options, class: css_class, aria: { label: 'Breadcrumbs,,' }) do %>
   <ol class="usa-breadcrumb__list">
     <%= content %>
   </ol>
-</nav>
+<% end %>

--- a/_components/breadcrumb_component.html.erb
+++ b/_components/breadcrumb_component.html.erb
@@ -1,4 +1,4 @@
-<nav class="usa-breadcrumb" aria-label="Breadcrumbs,,">
+<nav class="<%= css_class %>" aria-label="Breadcrumbs,,">
   <ol class="usa-breadcrumb__list">
     <%= content %>
   </ol>

--- a/_components/breadcrumb_component.rb
+++ b/_components/breadcrumb_component.rb
@@ -1,1 +1,11 @@
-class BreadcrumbComponent < BaseComponent; end
+class BreadcrumbComponent < BaseComponent
+  attr_reader :tag_options
+
+  def initialize(**tag_options)
+    @tag_options = tag_options
+  end
+
+  def css_class
+    ['usa-breadcrumb', *tag_options[:class]]
+  end
+end

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -23,7 +23,7 @@ layout: default
       {% if page.category %}
         {% assign home_url = "/" | prepend: site.baseurl %}
         {% assign category_url = page.category | slugify | prepend: "/categories/" | prepend: site.baseurl | append: ".html" %}
-        {% component breadcrumb %}
+        {% component breadcrumb class="padding-y-0" %}
           {% component breadcrumb_item href=home_url %}Home{% endcomponent %}
           {% component breadcrumb_item href=category_url %}{{ page.category }}{% endcomponent %}
           {% component breadcrumb_item href=page.url current %}{{ page.title }}{% endcomponent %}


### PR DESCRIPTION
## 🛠 Summary of changes

Adjusts visual appearance of breadcrumbs added in #628 to remove inherent padding from the component.

This is to tighten up spacing and remove awkward offset of beginning of page content relative to the sidebar.

## 📜 Testing Plan

1. Go to preview URL
2. Click on article or category
3. See that sidebar top matches content top

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/78fe6fc1-1203-4e5b-8fea-846b6d095df2)|![image](https://github.com/user-attachments/assets/340ac4ea-4693-40da-a2c8-7f6b0c4e35a0)
