### PR TITLE
Refine categories listing appearance and descriptions

### DIFF
--- a/_categories/development.md
+++ b/_categories/development.md
@@ -1,6 +1,6 @@
 ---
 title: Development
 layout: category
-description: Common Dev things across AppDev and DevOps
+description: Development topics common to AppDev and DevOps
 icon: keyboard
 ---

--- a/_categories/partnerships.md
+++ b/_categories/partnerships.md
@@ -1,5 +1,6 @@
 ---
 title: Partnerships
 layout: category
+description: Business development, account management, outreach, and communications
 icon: campaign
 ---

--- a/_categories/platform.md
+++ b/_categories/platform.md
@@ -1,5 +1,6 @@
 ---
 title: Platform
 layout: category
+description: Platform infrastructure and DevOps practices
 icon: build
 ---

--- a/_categories/private.md
+++ b/_categories/private.md
@@ -1,7 +1,0 @@
----
-title: Private Articles
-permalink: /private/
-layout: article
-icon: lock
-redirect_to: https://lg-public.pages.production.gitlab.login.gov/identity-internal-handbook/
----

--- a/_categories/product.md
+++ b/_categories/product.md
@@ -1,6 +1,6 @@
 ---
 title: Product
 layout: category
-description: Product and process
+description: Product delivery and process
 icon: science
 ---

--- a/_categories/reporting.md
+++ b/_categories/reporting.md
@@ -1,5 +1,6 @@
 ---
 title: Reporting
 layout: category
+description: Data analytics and key metrics reporting
 icon: insights
 ---

--- a/_categories/security.md
+++ b/_categories/security.md
@@ -1,5 +1,6 @@
 ---
 title: Security
 layout: category
+description: Security, anti-fraud, and incident response
 icon: security
 ---

--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -23,6 +23,21 @@
   }
 }
 
+.article-categories {
+  .usa-card {
+    @include u-margin-bottom(2);
+  }
+
+  .usa-card__heading {
+    display: flex;
+    align-items: center;
+
+    .usa-icon {
+      @include u-margin-right(1);
+    }
+  }
+}
+
 .deprecated-link {
   color: gray;
 }

--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ Internal documentation can be found in our [Internal Login.gov Handbook](https:/
 
 <div class="margin-bottom-4"></div>
 
-<ul class="usa-card-group">
+<ul class="article-categories usa-card-group">
   {% assign sorted_categories = site.categories | group_by: 'order' | sort: 'name' %}
   {% for category_group in sorted_categories %}
     {% assign sorted_category_items = category_group.items | sort: 'title' %}


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the display of handbook categories:

- Ensures description for each
- Reduce by one row / avoid odd-number items (remove "Private articles" in favor of #640)
- Visual refinements: Reduce spacing between rows to match columns, align heading icon

## 📜 Testing Plan

1. Visit preview URL
2. Observe list of categories meets criteria listed above

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/ea0503f6-f7b0-4125-8a11-5d461f7e680c)|![image](https://github.com/user-attachments/assets/3f237090-0b0b-40e5-8673-76ef022bd3b7)
