### PR TITLE
Collapse introductory paragraphs on homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,10 +5,8 @@ layout: article
 exclude_from_index: true
 ---
 
-Welcome to the Login.gov handbook! This is our open source team documentation!
-
-Please help us contribute and keep things up to date, and make sure
-to [avoid contributing sensitive information][sensitive-information].
+Welcome to the Login.gov handbook! This is our open source team documentation. Please help us keep
+things up to date, and make sure to [avoid contributing sensitive information][sensitive-information].
 
 [sensitive-information]: {{ site.baseurl }}/articles/contributing.html#sensitive-information
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the introduction text of the handbook to be collapsed to a single paragraph, so that people can quickly get to the good stuff.

## 📜 Testing Plan

1. Go to preview URL
2. Observe less scrolling effort to get to articles

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/a74438f2-1baf-4641-b2c8-9c7aedc15257)|![image](https://github.com/user-attachments/assets/88ce44a1-7178-4a97-8d67-00a95de92ac5)
