### PR TITLE
Remove inherent padding from breadcrumb (2)

### DIFF
--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -36,7 +36,7 @@ layout: default
   <div class="tablet:grid-col-8">
     <div class="usa-prose" role="main">
       {% assign home_url = "/" | prepend: site.baseurl %}
-      {% component breadcrumb %}
+      {% component breadcrumb class="padding-y-0" %}
         {% component breadcrumb_item href=home_url %}Home{% endcomponent %}
         {% component breadcrumb_item href=page.url current %}{{ page.title }}{% endcomponent %}
       {% endcomponent %}


### PR DESCRIPTION
## 🛠 Summary of changes

Quick follow-up to #642, applies padding changes to Categories layout as well, missed in that pull request.

## 📜 Testing Plan

Repeat Testing Plan from #642

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/5d16961d-354c-4e65-bb66-cfd446d174b1)|![image](https://github.com/user-attachments/assets/a35e82c5-31e8-41f7-ab8e-5af7e2b8cdf9)
