### PR TITLE
Exclude additional files irrelevant for published site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,13 +34,17 @@ plugins:
   - jekyll-environment-variables
 
 exclude:
+  - .cache
   - CONTRIBUTING.md
-  - SECURITY.md
-  - package-lock.json
-  - Makefile
-  - package.json
+  - cspell.json
+  - federalist.json
   - Gemfile
   - Gemfile.lock
+  - package-lock.json
+  - package.json
+  - Makefile
   - node_modules
+  - SECURITY.md
+  - spec
+  - tsconfig.json
   - vendor
-  - .cache


### PR DESCRIPTION
## 🛠 Summary of changes

Adds additional files to be excluded from built site which are relevant for development and build, but not for the published site:

- `cspell.json` (spell-checking in CI)
- `federalist.json` (used by Cloud.gov Pages during build)
- `spec` (tests run in CI)
- `tsconfig.json` (TypeScript configuration for JavaScript source files)

Also sorts the list.

## 📜 Testing Plan

Verify that `_site` contains only files that should be published to the live site:

```
rm -rf _site && bundle exec jekyll build
```