### PR TITLE
Remove unused jekyll-environment-variables gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem "view_component", "~> 3.20.0"
 group :jekyll_plugins do
   gem "jekyll-redirect-from"
   gem "jekyll-last-modified-at"
-  gem "jekyll-environment-variables"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,8 +82,6 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-environment-variables (1.0.1)
-      jekyll (>= 3.0, < 5.x)
     jekyll-last-modified-at (1.3.2)
       jekyll (>= 3.7, < 5.0)
     jekyll-redirect-from (0.16.0)
@@ -180,7 +178,6 @@ DEPENDENCIES
   activesupport (~> 8.0.0)
   html-proofer (~> 4.4.3)
   jekyll (~> 4)
-  jekyll-environment-variables
   jekyll-last-modified-at
   jekyll-redirect-from
   kramdown (>= 2.3.0)

--- a/_config.yml
+++ b/_config.yml
@@ -31,7 +31,6 @@ keep_files:
 plugins:
   - jekyll-redirect-from
   - jekyll-last-modified-at
-  - jekyll-environment-variables
 
 exclude:
   - CONTRIBUTING.md


### PR DESCRIPTION
## 🛠 Summary of changes

Removes unused `jekyll-environment-variables` gem.

Last reference removed in #541

## 📜 Testing Plan

Verify no code references to `site.env`