### PR TITLE
Use jekyll link tag for internal links instead of hardcoding production URLs

### DIFF
--- a/_articles/appdev-oncall-guide.md
+++ b/_articles/appdev-oncall-guide.md
@@ -108,7 +108,7 @@ Refer to [Troubleshooting expiring PIV/CAC certs]({% link _articles/troubleshoot
 
 ## Response Times
 
-SecOps Incident Response Guide located [here](https://handbook.login.gov/articles/secops-incident-response-guide.html)
+SecOps Incident Response Guide located [here]({% link _articles/incident-response-guide.md %})
 
 Things to consider when assessing severity:
 * If PII is involved

--- a/_articles/platform-acceptance-criteria.md
+++ b/_articles/platform-acceptance-criteria.md
@@ -80,7 +80,7 @@ As much as possible, PRs containing changes to cookbooks (whether in `identity-d
 
 Most of the style/formatting guidelines listed above for PRs can be similarly followed for Issues. As much as possible, use the in-repo templates (shown in the GitHub web interface, and/or the `.github/ISSUE_TEMPLATE` directory in the repo itself) when creating issues.
 
-Detailed information on how to effectively write and define Issues can be found in the [Definition Of Ready document in this handbook](https://handbook.login.gov/articles/definition-of-ready.html).
+Detailed information on how to effectively write and define Issues can be found in the [Definition Of Ready document in this handbook]({% link _articles/definition-of-ready.md %})
 
 ## Appendix
 

--- a/_articles/types-of-documentation.md
+++ b/_articles/types-of-documentation.md
@@ -14,7 +14,7 @@ to find in each.
 ## [Login.gov Public Handbook](https://handbook.login.gov/)
 
 - Contains up-to-date content relevant for the entire Login.gov program which is suitable to share
-  with the general public (see [_Sensitive Information_](https://handbook.login.gov/articles/contributing.html#sensitive-information))
+  with the general public (see [_Sensitive Information_]({% link _articles/contributing.md %}#sensitive-information))
 - Anyone can and should contribute, but content is written in [Markdown](https://en.wikipedia.org/wiki/Markdown)
   and therefore requires some understanding of Markdown syntax
 - Content is changed through pull requests in [the GitHub repository](https://github.com/GSA-TTS/identity-handbook),
@@ -26,7 +26,7 @@ to find in each.
 ## [Login.gov Internal Handbook](https://lg-public.pages.production.gitlab.login.gov/identity-internal-handbook/)
 
 - Contains up-to-date content relevant for the entire Login.gov program which is not suitable to
-  share with the general public (see [_Sensitive Information_](https://handbook.login.gov/articles/contributing.html#sensitive-information))
+  share with the general public (see [_Sensitive Information_]({% link _articles/contributing.md %}#sensitive-information))
 - Anyone can and should contribute, but content is written in [Markdown](https://en.wikipedia.org/wiki/Markdown)
   and therefore requires some understanding of Markdown syntax
 - Content is changed through pull requests in [the GitHub repository](https://github.com/GSA-TTS/identity-handbook),


### PR DESCRIPTION
## 🛠 Summary of changes

Makes a couple small fixes to prefer usage of `link` with a page rather than `handbook.login.gov`.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.
-->
