### PR TITLE
Document additional options for CloudWatch uniqueness

### DIFF
--- a/_articles/cloudwatch-101.md
+++ b/_articles/cloudwatch-101.md
@@ -152,7 +152,7 @@ To work around this, there are a few options
     ```
     | stats count(*) by PROPERTY_TO_COUNT
     ```
-- If you're trying to deduplicate events logged in the same session, you can `filter properties.new_event` to consider events logged for the first time in a session
+- If you're trying to deduplicate events logged in the same session, you can `filter properties.new_event` to consider events logged for the first time in a session. Note that `new_event` will always be `true` for "successful" events (`properties.event_properties.success`).
 - CloudWatch supports multiple `stats` aggregation, so you can group by a property occurring at least once before summing a count. Note that these can be query-intensive and take a long time to run.
 
     ```

--- a/_articles/cloudwatch-101.md
+++ b/_articles/cloudwatch-101.md
@@ -152,6 +152,15 @@ To work around this, there are a few options
     ```
     | stats count(*) by PROPERTY_TO_COUNT
     ```
+- If you're trying to deduplicate events logged in the same session, you can `filter properties.new_event` to consider events logged for the first time in a session
+- CloudWatch supports multiple `stats` aggregation, so you can group by a property occurring at least once before summing a count. Note that these can be query-intensive and take a long time to run.
+
+    ```
+    filter name = 'some_page_visited'
+    | stats count(*) > 0 as visited_once by properties.user_id
+    | stats sum(visited_once)
+    ```
+
 
 [aws-docs]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html
 [count-distinct]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax-Stats.html#:~:text=Returns%20the%20number%20of%20unique%20values%20for%20the%20field.%20If%20the%20field%20has%20very%20high%20cardinality%20(contains%20many%20unique%20values)%2C%20the%20value%20returned%20by%20count_distinct%20is%20just%20an%20approximation.


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the ["CloudWatch 101" article section on `count_distinct`](https://handbook.login.gov/articles/cloudwatch-101.html#count_distinct) to include two more options for querying unique values (`new_event`, multiple `stats` aggregation).

Related Slack discussion: https://gsa-tts.slack.com/archives/C01710KMYUB/p1740147681093639

## 📜 Testing Plan

Verify readability and accuracy of the documented alternative suggestions to `count_distinct`.

Live preview: https://federalist-7d0b2b76-42fc-4df1-9825-8c3cd77e0a15.sites.pages.cloud.gov/preview/gsa-tts/identity-handbook/aduth-cloudwatch-uniqueness/articles/cloudwatch-101.html#count_distinct