### PR TITLE
Add new content for partnerships page

### DIFF
--- a/_articles/partnerships-advisory-group.md
+++ b/_articles/partnerships-advisory-group.md
@@ -1,0 +1,8 @@
+---
+title: Quarterly Partner Advisory Group (PAG)
+description: The PAG is a venue for partners to offer early input and feedback on Login.gov's strategic direction. It consists of a small group of executive and program-level staff from partner agencies.
+layout: article
+category: Partnerships
+subcategory: Partner communication channels
+redirect_to: https://docs.google.com/document/d/1R9DJL6QAQ8lrOaVMJFqD8tK7jgNd4Nkcccl_tT7bviI/edit?tab=t.0#heading=h.2qwqsxdil4hl
+---

--- a/_articles/partnerships-contact-us-webpage.md
+++ b/_articles/partnerships-contact-us-webpage.md
@@ -1,0 +1,8 @@
+---
+title: Contact Us webpage
+description: Users can submit a help ticket using the form on this webpage to get more hands-on support.
+layout: article
+category: Partnerships
+subcategory: Resources for end users
+redirect_to: https://www.login.gov/contact/
+---

--- a/_articles/partnerships-dashboard.md
+++ b/_articles/partnerships-dashboard.md
@@ -1,0 +1,8 @@
+---
+title: Partnerships dashboard
+description: The Partnerships Team reports on progress achieved toward strategic objectives and key results as well as program revenue targets in the Partnerships Dashboard.
+layout: article
+category: Partnerships
+subcategory: Strategy and performance
+redirect_to: https://airtable.com/appjJSxv1OhUs3oE1/tbl4sYQUhu2JEk1be/viwfB0kIQjdN77mSz?blocks=hide
+---

--- a/_articles/partnerships-external-slack.md
+++ b/_articles/partnerships-external-slack.md
@@ -1,0 +1,8 @@
+---
+title: Slack
+description: Partners can use this channel to reach us between 9 am - 4 pm Eastern, excluding Federal holidays.
+layout: article
+category: Partnerships
+subcategory: Partner communication channels
+redirect_to: https://gsa.enterprise.slack.com/archives/CG64NU5C7
+---

--- a/_articles/partnerships-guides-faqs.md
+++ b/_articles/partnerships-guides-faqs.md
@@ -1,0 +1,8 @@
+---
+title: Guides and FAQs
+description: Partnerships Team collaborates with product teams to develop guides on high-level topics. These guides include descriptions of service offerings as well as answers to commonly asked questions.
+layout: article
+category: Partnerships
+subcategory: Internal tools and resources
+redirect_to: https://drive.google.com/drive/folders/1ya01Kj8GVrTG71zq5_B9n8q13V17eAHk
+---

--- a/_articles/partnerships-help-center.md
+++ b/_articles/partnerships-help-center.md
@@ -1,0 +1,8 @@
+---
+title: Help Center
+description: Users have access to a series of articles that provide answers to commonly asked questions.
+layout: article
+category: Partnerships
+subcategory: Resources for end users
+redirect_to: https://login.gov/help/
+---

--- a/_articles/partnerships-internal-slack.md
+++ b/_articles/partnerships-internal-slack.md
@@ -1,0 +1,8 @@
+---
+title: Slack
+description: The Partnerships Team uses various Slack channels to communicate internally, across the program, and externally with partners.
+layout: article
+category: Partnerships
+subcategory: Internal tools and resources
+redirect_to: https://gsa.enterprise.slack.com/archives/C23LEJLMC
+---

--- a/_articles/partnerships-market-segments.md
+++ b/_articles/partnerships-market-segments.md
@@ -1,0 +1,8 @@
+---
+title: Market segments and pods
+description: The Partnerships Team services five market segments – Benefits, Defense, Finance & Regulation, Infrastructure, and State & Local. Each market segment has a designated account manager, business development lead, and partner success manager. We call these cross-function teams \"pods."
+layout: article
+category: Partnerships
+subcategory: Organizational structure
+redirect_to: https://airtable.com/appCPBIq0sFQUZUSY/shrlTeEabqxN86mlz/tblu0YYt8ffuWZ2ef
+---

--- a/_articles/partnerships-newsletter.md
+++ b/_articles/partnerships-newsletter.md
@@ -1,0 +1,8 @@
+---
+title: "Monthly partner newsletter"
+description: Outreach sends partners a monthly newsletter on the latest developments.
+layout: article
+category: Partnerships
+subcategory: Partner communication channels
+redirect_to: https://forms.gle/fuZghgpP6uD4s6GH9
+---

--- a/_articles/partnerships-organizational-structure.md
+++ b/_articles/partnerships-organizational-structure.md
@@ -1,0 +1,8 @@
+---
+title: Partnerships Org Chart
+description: The Partnerships Team is responsible for account management, business development, partner success, outreach, and user support.
+layout: article
+category: Partnerships
+subcategory: Organizational structure
+redirect_to: https://docs.google.com/drawings/d/12_AWBuSUvKgMIoQOaBKzohORCOOAdoTpGSN8VwQruPA/edit?usp=sharing
+---

--- a/_articles/partnerships-press-kit.md
+++ b/_articles/partnerships-press-kit.md
@@ -1,0 +1,8 @@
+---
+title: Login.gov press kit
+description: The press kit is intended to be a resource for partners’ communications/media affairs offices.
+layout: article
+category: Partnerships
+subcategory: External Resources
+redirect_to: https://login.gov/docs/login-gov-press-kit.pdf
+---

--- a/_articles/partnerships-program-roadmap.md
+++ b/_articles/partnerships-program-roadmap.md
@@ -1,0 +1,8 @@
+---
+title: Program roadmap
+description: Login.gov shares its strategic priorities in the publicly available program roadmap.
+layout: article
+category: Partnerships
+subcategory: External Resources
+redirect_to: https://docs.google.com/presentation/d/1dxc1T8KJM0e8EZGwGNtGSwaV0dnZh0uAUuB14lhwXY4/edit#slide=id.g24c0f42ebb8_39_15
+---

--- a/_articles/partnerships-program-updates.md
+++ b/_articles/partnerships-program-updates.md
@@ -1,0 +1,8 @@
+---
+title: "Program updates webpage"
+description: This page serves as a platform to highlight high-impact features, demonstrate the program’s impact on government-wide initiatives, and showcase thought leadership.
+layout: article
+category: Partnerships
+subcategory: External Resources
+redirect_to: https://login.gov/partners/program-updates/
+---

--- a/_articles/partnerships-webinar.md
+++ b/_articles/partnerships-webinar.md
@@ -1,0 +1,8 @@
+---
+title: Quarterly product update webinar
+description: The quarterly product update webinar provides partners in-depth insight into planned and recent feature enhancements. Attendees consist of a broad range of staff from partner agencies.
+layout: article
+category: Partnerships
+subcategory: Partner communication channels
+redirect_to: https://drive.google.com/drive/folders/1IO7eNStbKWpJTSHdqgTK-MQ4x2wfVN11
+---

--- a/_articles/partnerships-zendesk.md
+++ b/_articles/partnerships-zendesk.md
@@ -1,0 +1,8 @@
+---
+title: Zendesk
+description: Partners submit situation- and application-specific inquiries through Zendesk.
+layout: article
+category: Partnerships
+subcategory: Internal tools and resources
+redirect_to: https://zendesk.login.gov/
+---

--- a/assets/js/setup.ts
+++ b/assets/js/setup.ts
@@ -13,6 +13,8 @@ export const loadPrivateEye = () => {
   new PrivateEye({
     defaultMessage: "This link is private to TTS.",
     ignoreUrls: [
+      "airtable.com",
+      "gsa.enterprise.slack.com",
       "18f.slack.com",
       "anywhere.gsa.gov",
       "bookit.gsa.gov",


### PR DESCRIPTION
## 🛠 Summary of changes

Ticket: [!165](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/165)

The Outreach team has drafted content and new pages to add documentation for the Partnerships team, and this PR implements it.