### PR TITLE
Remove manual testing from deploy process

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -225,12 +225,7 @@ Staging used to be deployed by this process, but this was changed to deploy the 
 
 7. Set a timer for one hour, then check NewRelic again for errors.
 
-8. Manually test the app in production:
-    - Sign in to an account
-    - Sign up for an account
-    - Test proofing (identity verification) on the new account
-
-9. If everything looks good, the deploy is complete.
+8. If everything looks good, the deploy is complete.
 
 #### Creating a Release (Production only)
 


### PR DESCRIPTION
## 🛠 Summary of changes

Based on discussion in the [2025-06-18](https://docs.google.com/document/d/1g_V2vlT79tScBKIVw7M4UXf15TrG69iUrLHE0yE1GGI/edit?tab=t.0#heading=h.s3svy7wb0by6) engineering huddle, the manual testing has gotten more burdensome and less valuable. We have metrics and alerts that should notify us if something is going wrong. The identity verification team also currently does regular manual testing of the document verification step so part of this work is duplicative.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.
-->
