### PR TITLE
LG-16339: Update vendor-outage-response-process.md

### DIFF
--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -43,6 +43,7 @@ maintenance window, and restart server instances again.
 | LexisNexis Phone Finder   | TBD                                                                                                                                |
 | ThreatMetrix              | [Runbook: ThreatMetrix outage](https://gitlab.login.gov/lg/identity-devops/-/wikis/Runbook:-ThreatMetrix-outage)
 | Pinpoint                  | TBD                                                                                                                                |
+| DoS Passport API          | [Runbook: DoS Passport API outage](https://gitlab.login.gov/lg/identity-devops/-/wikis/Runbook:-DoS-Passport-API-outage)           |
 
 ### Contact Information
 


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a link to the `DoS Passport API outage` runbook

